### PR TITLE
FEAT: remove highlight execution

### DIFF
--- a/src/lib/code-diff/index.vue
+++ b/src/lib/code-diff/index.vue
@@ -1,7 +1,6 @@
 <template>
   <div id="app">
-    <div
-      v-highlight
+    <div      
       v-html="html"
     />
   </div>
@@ -16,12 +15,14 @@ import 'diff2html/bundles/css/diff2html.min.css'
 export default {
   name: 'CodeDiff',
   directives: {
-    highlight: function (el) {
-      const blocks = el.querySelectorAll('code')
-      blocks.forEach((block) => {
-        hljs.highlightBlock(block)
-      })
-    }
+    // This made everything slow AF
+    // highlight: function (el) {
+    //   const blocks = el.querySelectorAll('code')
+    //   blocks.forEach((block) => {
+    //     console.log('wtf')
+    //     hljs.highlightBlock(block)
+    //   })    
+    // }
   },
   props: {
     oldString: {


### PR DESCRIPTION
Showing diffs was taking _forever_ because of some large blocking highlight.js operation that I barely need. JSON really doesn't have that much syntax highlighting and there doesn't seem to be a way to turn it off dynamically through the original module. So I just took it out lol